### PR TITLE
ENH: fix image vertical mirrior issue

### DIFF
--- a/glimageview.cpp
+++ b/glimageview.cpp
@@ -91,38 +91,39 @@ void GLImageView::drawImage() {
     vao.bind();
 
     // setup vertex buffer object
+    // vertex coords and texture coords should be mirriored in the vertical direction
     std::vector<GLfloat> coords;
     // bottom left;
     coords.push_back(-1.0f);
     coords.push_back(-1.0f * norm_h);
     coords.push_back(0.0f);
-    // tex coordinate
+    // tex coordinate top left
     coords.push_back(0.0f);
-    coords.push_back(0.0f);
+    coords.push_back(1.0f);
 
     // bottom right
     coords.push_back(1.0f);
     coords.push_back(-1.0f * norm_h);
     coords.push_back(0.0f);
-    // tex coordinate
+    // tex coordinate top right
     coords.push_back(1.0f);
-    coords.push_back(0.0f);
+    coords.push_back(1.0f);
 
     // top right
     coords.push_back(1.0f);
     coords.push_back(1.0f * norm_h);
     coords.push_back(0.0f);
-    // tex coordinate
+    // tex coordinate bottom right
     coords.push_back(1.0f);
-    coords.push_back(1.0f);
+    coords.push_back(0.0f);
 
     // top left
     coords.push_back(-1.0f);
     coords.push_back(1.0f * norm_h);
     coords.push_back(0.0f);
-    // tex coordinate
+    // tex coordinate bottom left
     coords.push_back(0.0f);
-    coords.push_back(1.0f);
+    coords.push_back(0.0f);
 
     if (!vbo.isCreated())
     {
@@ -218,7 +219,7 @@ void GLImageView::setupDefaultTransform() {
 }
 
 void GLImageView::loadImage(QString& path) {
-    QImage* p = new QImage(QImage(path).mirrored());
+    QImage* p = new QImage(path);
     image = std::unique_ptr<QImage>(p);
     isTextureSync = false;
     norm_h = (float)((float)image->height()/(float)image->width());

--- a/glimageview.cpp
+++ b/glimageview.cpp
@@ -41,11 +41,15 @@ void GLImageView::initializeGL()
 {
     initializeOpenGLFunctions();
     setupDefaultShaderProgram();
+
+    glClearColor(static_cast<GLclampf>(clearColor.redF()),
+                 static_cast<GLclampf>(clearColor.greenF()),
+                 static_cast<GLclampf>(clearColor.blueF()),
+                 static_cast<GLclampf>(clearColor.alphaF()) );
 }
 
 void GLImageView::paintGL()
 {
-    glClearColor(clearColor.redF(), clearColor.greenF(), clearColor.blueF(), clearColor.alphaF());
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
     drawImage();
 }


### PR DESCRIPTION
    vertex coords and texture coords
    should be mirriored in the vertical direction

Signed-off-by: dan.cao <caodan@linuxtoy.cn>